### PR TITLE
Remove a link to Pilot from the main menu. We are going to production.

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -62,13 +62,6 @@ const Navbar = class extends React.Component {
               <Link
                 activeClassName="is-active"
                 className="navbar-item"
-                to="/pilot"
-              >
-                Pilot
-              </Link>
-              <Link
-                activeClassName="is-active"
-                className="navbar-item"
                 to="/products"
               >
                 Products


### PR DESCRIPTION
Remove a link to Pilot from the main menu
The page itself and associated form to remain available for backward compatibility